### PR TITLE
Task03: cd ls

### DIFF
--- a/src/main/java/ru/spbau/mit/ShellImpl.java
+++ b/src/main/java/ru/spbau/mit/ShellImpl.java
@@ -106,6 +106,7 @@ public final class ShellImpl implements Shell {
         commandFactory.registerCommand(WcCommand.class);
         commandFactory.registerCommand(ExitCommand.class);
         commandFactory.registerCommand(GrepCommand.class);
+        commandFactory.registerCommand(CdCommand.class);
     }
 
     /**

--- a/src/main/java/ru/spbau/mit/ShellImpl.java
+++ b/src/main/java/ru/spbau/mit/ShellImpl.java
@@ -107,6 +107,7 @@ public final class ShellImpl implements Shell {
         commandFactory.registerCommand(ExitCommand.class);
         commandFactory.registerCommand(GrepCommand.class);
         commandFactory.registerCommand(CdCommand.class);
+        commandFactory.registerCommand(LsCommand.class);
     }
 
     /**

--- a/src/main/java/ru/spbau/mit/commands/CdCommand.java
+++ b/src/main/java/ru/spbau/mit/commands/CdCommand.java
@@ -1,0 +1,50 @@
+package ru.spbau.mit.commands;
+
+import org.jetbrains.annotations.NotNull;
+import ru.spbau.mit.Shell;
+import ru.spbau.mit.parsing.Token;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * <code>cd</code> command.
+ */
+@CommandAnnotation(commandName = "cd")
+public final class CdCommand extends Command {
+    @NotNull
+    private static final Logger LOGGER = Logger.getLogger(CdCommand.class.getName());
+
+    /**
+     * {@inheritDoc}
+     */
+    public CdCommand(@NotNull Shell shell, @NotNull OutputStream out) {
+        super(shell, out);
+    }
+
+    /**
+     * execute <code>cd</code> command
+     * @param in ignored
+     * @param args arg should contain a single item - directory to cd to
+     */
+    @Override
+    public int execute(@NotNull InputStream in, @NotNull Token[] args) {
+        if (args.length != 1) {
+            LOGGER.log(Level.WARNING, "cd expected exactly one argument, got " + args.length);
+            return 1;
+        }
+        Path path = Paths.get(args[0].getContent());
+        if (path.isAbsolute()) {
+            shell.changeDirectory(path.normalize().toString());
+        } else {
+            shell.changeDirectory(Paths.get(shell.pwd()).resolve(path).normalize().toString());
+        }
+        return 0;
+    }
+}

--- a/src/main/java/ru/spbau/mit/commands/CdCommand.java
+++ b/src/main/java/ru/spbau/mit/commands/CdCommand.java
@@ -4,8 +4,6 @@ import org.jetbrains.annotations.NotNull;
 import ru.spbau.mit.Shell;
 import ru.spbau.mit.parsing.Token;
 
-import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;

--- a/src/main/java/ru/spbau/mit/commands/LsCommand.java
+++ b/src/main/java/ru/spbau/mit/commands/LsCommand.java
@@ -4,7 +4,6 @@ import org.jetbrains.annotations.NotNull;
 import ru.spbau.mit.Shell;
 import ru.spbau.mit.parsing.Token;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/src/main/java/ru/spbau/mit/commands/LsCommand.java
+++ b/src/main/java/ru/spbau/mit/commands/LsCommand.java
@@ -1,0 +1,57 @@
+package ru.spbau.mit.commands;
+
+import org.jetbrains.annotations.NotNull;
+import ru.spbau.mit.Shell;
+import ru.spbau.mit.parsing.Token;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * <code>ls</code> command.
+ */
+@CommandAnnotation(commandName = "ls")
+public class LsCommand extends Command {
+
+    @NotNull private static final Logger LOGGER = Logger.getLogger(LsCommand.class.getName());
+
+    /**
+     * {@inheritDoc}
+     */
+    public LsCommand(@NotNull Shell shell, @NotNull OutputStream out) {
+        super(shell, out);
+    }
+
+    /**
+     * execute <code>ls</code> command
+     * @param in ignored
+     * @param args the only argument should contain directory to list. If <code>args</code> is empty, current directory is listed.
+     */
+    @Override
+    public int execute(@NotNull InputStream in, @NotNull Token[] args) {
+        if (args.length > 1) {
+            LOGGER.log(Level.WARNING, "Expected not more than 1 argument for ls, got " + args.length);
+            return 1;
+        }
+        Path dir = Paths.get(args.length == 0 ? "" : args[0].getContent());
+        if (!dir.isAbsolute()) {
+            dir = Paths.get(shell.pwd()).resolve(dir);
+        }
+        try {
+            for (Path p : Files.newDirectoryStream(dir)) {
+                out.write((p.getFileName().toString() + "\n").getBytes());
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Error while executing", e);
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/ru/spbau/mit/commands/OuterShellCommand.java
+++ b/src/main/java/ru/spbau/mit/commands/OuterShellCommand.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import ru.spbau.mit.Shell;
 import ru.spbau.mit.parsing.Token;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -43,6 +44,7 @@ public final class OuterShellCommand extends Command {
 
         try {
             final ProcessBuilder processBuilder = new ProcessBuilder(processArgs);
+            processBuilder.directory(new File(shell.pwd()));
             final Process process = processBuilder.start();
             final OutputStream processInput = process.getOutputStream();
 

--- a/src/test/java/ru/spbau/mit/commands/CdCommandTest.java
+++ b/src/test/java/ru/spbau/mit/commands/CdCommandTest.java
@@ -1,0 +1,68 @@
+package ru.spbau.mit.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import ru.spbau.mit.Shell;
+import ru.spbau.mit.ShellImpl;
+import ru.spbau.mit.parsing.Token;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public final class CdCommandTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws IOException {
+        temporaryFolder.create();
+        temporaryFolder.newFolder("subfolder1");
+        temporaryFolder.newFolder("subfolder2");
+    }
+
+    @Test
+    public void testCdRelative() throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final Shell shell = new ShellImpl(CommandFactory.INSTANCE, System.in, System.out);
+        shell.changeDirectory(temporaryFolder.getRoot().getAbsolutePath());
+        CdCommand cdCommand = new CdCommand(shell, out);
+
+        assertEquals(0, cdCommand.execute(System.in, new Token[] {
+                new Token(Token.TokenType.WORD, "subfolder1")
+        }));
+        assertEquals("", out.toString());
+        assertEquals(new File(temporaryFolder.getRoot(), "subfolder1").getAbsolutePath(), shell.pwd());
+    }
+
+    @Test
+    public void testCdAbsolute() throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final Shell shell = new ShellImpl(CommandFactory.INSTANCE, System.in, System.out);
+        CdCommand cdCommand = new CdCommand(shell, out);
+
+        assertEquals(0, cdCommand.execute(System.in, new Token[] {
+                new Token(Token.TokenType.WORD, temporaryFolder.getRoot().getAbsolutePath())
+        }));
+        assertEquals("", out.toString());
+        assertEquals(temporaryFolder.getRoot().getAbsolutePath(), shell.pwd());
+    }
+
+    @Test
+    public void testCdParent() throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final Shell shell = new ShellImpl(CommandFactory.INSTANCE, System.in, System.out);
+        shell.changeDirectory(new File(temporaryFolder.getRoot(), "subfolder1").getAbsolutePath());
+        CdCommand cdCommand = new CdCommand(shell, out);
+
+        assertEquals(0, cdCommand.execute(System.in, new Token[] {
+                new Token(Token.TokenType.WORD, "..")
+        }));
+        assertEquals("", out.toString());
+        assertEquals(temporaryFolder.getRoot().getAbsolutePath(), shell.pwd());
+    }
+}

--- a/src/test/java/ru/spbau/mit/commands/LsCommandTest.java
+++ b/src/test/java/ru/spbau/mit/commands/LsCommandTest.java
@@ -1,0 +1,80 @@
+package ru.spbau.mit.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import ru.spbau.mit.Shell;
+import ru.spbau.mit.ShellImpl;
+import ru.spbau.mit.parsing.Token;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public final class LsCommandTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws IOException {
+        temporaryFolder.create();
+        temporaryFolder.newFile("a.txt");
+        temporaryFolder.newFile("z.txt");
+        File subfolder1 = temporaryFolder.newFolder("subfolder1");
+        File subfolder2 = temporaryFolder.newFolder("subfolder2");
+        new File(subfolder1, "b.txt").createNewFile();
+        new File(subfolder1, "bz").mkdir();
+        new File(subfolder1, "c.txt").createNewFile();
+
+        new File(subfolder2, "d.txt").createNewFile();
+        new File(subfolder2, "dz").mkdir();
+        new File(subfolder2, "e.txt").createNewFile();
+    }
+
+    @Test
+    public void testLsRelative() throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final Shell shell = new ShellImpl(CommandFactory.INSTANCE, System.in, System.out);
+        shell.changeDirectory(temporaryFolder.getRoot().getAbsolutePath());
+        LsCommand lsCommand = new LsCommand(shell, out);
+
+        assertEquals(0, lsCommand.execute(System.in, new Token[] {
+                new Token(Token.TokenType.WORD, "subfolder1")
+        }));
+        String[] output = out.toString().split("\n");
+        Arrays.sort(output);
+        assertArrayEquals(new String[] { "b.txt", "bz", "c.txt" }, output);
+    }
+
+    @Test
+    public void testLsAbsolute() throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final Shell shell = new ShellImpl(CommandFactory.INSTANCE, System.in, System.out);
+        LsCommand lsCommand = new LsCommand(shell, out);
+
+        assertEquals(0, lsCommand.execute(System.in, new Token[] {
+                new Token(Token.TokenType.WORD, new File(temporaryFolder.getRoot(), "subfolder2").getAbsolutePath())
+        }));
+        String[] output = out.toString().split("\n");
+        Arrays.sort(output);
+        assertArrayEquals(new String[] { "d.txt", "dz", "e.txt" }, output);
+    }
+
+    @Test
+    public void testLsCurrentDir() throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final Shell shell = new ShellImpl(CommandFactory.INSTANCE, System.in, System.out);
+        shell.changeDirectory(temporaryFolder.getRoot().getAbsolutePath());
+        LsCommand lsCommand = new LsCommand(shell, out);
+
+        assertEquals(0, lsCommand.execute(System.in, new Token[] {}));
+        String[] output = out.toString().split("\n");
+        Arrays.sort(output);
+        assertArrayEquals(new String[] { "a.txt", "subfolder1", "subfolder2", "z.txt" }, output);
+    }
+}


### PR DESCRIPTION
Что оказалось удобным:

1. Все встроенные команды построены по одному шаблону: класс, аннотация, подключение в `ShellImpl`.
2. Команде доступен простой интерфейс для получения аргументов (уже разбиты по токенам), вывода (`OutputStream`) и сообщения об ошибке (вернуть ненулевой код, вывести сообщение в лог).
3. Есть примеры тестов, которые легко адаптируются под новые команды.
4. У `Shell` есть переменная "текущая папка" и процедура для её модификации.
5. `Shell.setCurrentDirectory()` проверяет существование папки.
6. Сборка и тесты под Maven работают под Linux.

Что оказалось неудобным:
1. Методы получения/изменения текущей директории называются несимметрично: `changeDirectory()` и `pwd()` (вместо `getDirectory()` или `cd()`).
2. Текущая директория в `Shell` хранится в `String`, таким образом, для корректной платформонезависимой работы с путями через `java.io.File`/`java.nio.file.Path` требуется постоянно преобразовывать.
3. Никак не форсируется инвариант "путь в `Shell.pwd()` должен быть абсолютным".
4. Текущая директория не наследуется создаваемым процессом (`OuterShellCommand`), пришлось пофиксить.
5. В `pom.xml` отсутствуют правила для сборки jar со всеми зависимостями или цель `exec:java` т.е. без дополнительных танцев с бубном можно запускать только из IDE.
6. Тесты под Windows падают, из-за чего не представляется возможным проверить отсутствие регрессий. Основная причина - некорректная обработка абсолютных путей (которые в Windows начинаются с буквы диска: `C:\`, а не с прямого слэша).